### PR TITLE
Use remote url from docs

### DIFF
--- a/src/nordvpn
+++ b/src/nordvpn
@@ -84,7 +84,7 @@ update_files() {
         esac
     done
 
-    local remote_url=https://nordvpn.com/api/files/zipv2
+    local remote_url=https://downloads.nordcdn.com/configs/archives/servers/ovpn.zip
 
     local targetdir=/etc/openvpn/client/nordvpn
     mkdir -p $targetdir


### PR DESCRIPTION
As reported in #47 , the remote url does not work anymore. This PR changes it to https://downloads.nordcdn.com/configs/archives/servers/ovpn.zip as documented on
https://support.nordvpn.com/Connectivity/Linux/1061938702/How-to-connect-to-NordVPN-using-Linux-Network-Manager.htm
